### PR TITLE
Properly set `MORYX_COMMERCIAL_BUILD` env variable

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       NUGET_PACKAGES: ${{ github.workspace }}/.nuget/packages
-      BUILD_COMMERCIAL: "true"
+      MORYX_COMMERCIAL_BUILD: ${{ inputs.MORYX_COMMERCIAL_BUILD }}
     steps:
       - uses: actions/checkout@v4
 
@@ -90,7 +90,6 @@ jobs:
 
       - name: 🔨 Execute dotnet build
         run: |
-          echo "MORYX_COMMERCIAL_BUILD=${{ inputs.MORYX_COMMERCIAL_BUILD }}" | Out-File -FilePath $env:GITHUB_ENV -Append
           .\set-version.ps1 -RefName ${{ github.ref_name }} -IsTag ${{ github.ref_type == 'tag' && 1 || 0 }} -BuildNumber ${{ github.run_number }} -CommitHash ${{ github.sha }}
           .\build.ps1 -PackageSource ${{ github.workspace }}/.nuget/packages
         shell: pwsh

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -19,6 +19,10 @@ on:
         required: false
         type: string
         default: ""
+      MORYX_COMMERCIAL_BUILD:
+        required: false 
+        type: boolean
+        default: true
     secrets:
       npm_auth_token:
         required: false
@@ -34,6 +38,8 @@ jobs:
     runs-on: ubuntu-latest
     concurrency:
       group: publish
+    env:
+      MORYX_COMMERCIAL_BUILD: ${{ inputs.MORYX_COMMERCIAL_BUILD }}
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
`MORYX_COMMERCIAL_BUILD` is not only required to be set when buiding, but already at restoring. This is why it is set in the `env` section instead of during the `Build` step in `build.yml` as well as in `publish-packages.yml`.