### PR TITLE
Run tests with `MORYX_COMMERCIAL_BUILD` set to `false`

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -21,6 +21,10 @@ on:
         required: false
         type: string
         default: '20'
+      MORYX_COMMERCIAL_BUILD:
+        required: false 
+        type: boolean
+        default: false
     secrets:
       npm_auth_token:
         required: false
@@ -34,16 +38,10 @@ on:
 jobs:
   Tests:
     runs-on: ubuntu-latest
+    env:
+      MORYX_COMMERCIAL_BUILD: ${{ inputs.MORYX_COMMERCIAL_BUILD }}
     steps:
       - uses: actions/checkout@v4
-
-      # - uses: actions/cache@v4
-      #   id: cache-nuget
-      #   with:
-      #     path:  ${{ github.workspace }}/.nuget/packages
-      #     key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj') }}
-      #     restore-keys: |
-      #       ${{ runner.os }}-nuget-
 
       - name: 🔧 Setup Node
         uses: actions/setup-node@v4


### PR DESCRIPTION
While the `MORYX_COMMERCIAL_BUILD` is set to `true` by default, this is not the case for (unit) tests. So it needs explicitly be disabled which is also configurable now.